### PR TITLE
Two small fixes for rem

### DIFF
--- a/CSV.js
+++ b/CSV.js
@@ -6,8 +6,8 @@ module.exports = {
       if (csv[i] === "\"") {
         start = i + 1
         while (++i) {
-          if (csv[i] === "\\") i += 2
           if (csv[i] === "\"") break
+          if (csv[i] === "\\") i += 1
         }
         var value = csv.substring(start, i).replace(/\\(.)/g, "$1")
         if (header) keys.push(value)

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ http.createServer(function route(req, res) {
 		if (req.method === "GET") {
 			res.writeHead(200, {
 				"Content-Type": "application/json",
-				"Access-Control-Allow-Origin": req.headers.origin,
+				"Access-Control-Allow-Origin": req.headers.origin || '',
 				"Access-Control-Allow-Credentials": "true",
 			})
 			var offset = isNaN(parseInt(q.offset, 10)) ? 0 : parseInt(q.offset, 10)
@@ -68,7 +68,7 @@ http.createServer(function route(req, res) {
 						res.writeHead(200, {
 							"Content-Type": "application/json",
 							"Set-Cookie": output,
-							"Access-Control-Allow-Origin": req.headers.origin,
+							"Access-Control-Allow-Origin": req.headers.origin || '',
 							"Access-Control-Allow-Credentials": "true",
 						})
 						res.end(JSON.stringify(item, null, 2))
@@ -79,7 +79,7 @@ http.createServer(function route(req, res) {
 						res.writeHead(500, {
 							"Content-Type": "application/json",
 							"Set-Cookie": output,
-							"Access-Control-Allow-Origin": req.headers.origin,
+							"Access-Control-Allow-Origin": req.headers.origin || '',
 							"Access-Control-Allow-Credentials": "true",
 						})
 						res.end(JSON.stringify({message: error.message, stack: e.stack}, null, 2))
@@ -89,7 +89,7 @@ http.createServer(function route(req, res) {
 					console.log(e)
 					res.writeHead((e && e.method) || 400, {
 						"Content-Type": "application/json",
-						"Access-Control-Allow-Origin": req.headers.origin,
+						"Access-Control-Allow-Origin": req.headers.origin || '',
 						"Access-Control-Allow-Credentials": "true",
 					})
 					res.end(JSON.stringify({message: e.message, stack: e.stack}, null, 2))
@@ -98,7 +98,7 @@ http.createServer(function route(req, res) {
 		}
 		else if (req.method === "OPTIONS") {
 			res.writeHead(200, {
-				"Access-Control-Allow-Origin": req.headers.origin,
+				"Access-Control-Allow-Origin": req.headers.origin || '',
 				"Access-Control-Allow-Credentials": "true",
 				"Access-Control-Allow-Methods": "GET,POST,PUT,DELETE,OPTIONS",
 				"Access-Control-Allow-Headers": "Content-Type,Rem-Response-Status",
@@ -111,7 +111,7 @@ http.createServer(function route(req, res) {
 	catch (e) {
 		res.writeHead(e.method || 400, {
 			"Content-Type": "application/json",
-			"Access-Control-Allow-Origin": req.headers.origin,
+			"Access-Control-Allow-Origin": req.headers.origin || '',
 			"Access-Control-Allow-Credentials": "true",
 		})
 		res.end(JSON.stringify({message: e.message, stack: e.stack}, null, 2))


### PR DESCRIPTION
Hi!, Thanks for rem it is very useful 😃

I think I have found (and fixed) two small bugs.

1) The CSV.js has difficulty parsing back CSV with embedded commas. This can happen if you attempt to `POST`/`PUT` a json object containing an array, for example: `{"items":[1,"2",3]}`. Repro:
```
$ curl -c cookie-jar.txt -b cookie-jar.txt -X POST \
     --header "Content-Type: application/json"  \
     --data '{"items":[1,"2",3]}'  \
     http://rem-rest-api.herokuapp.com/api/foo
{
  "items": [
    1,
    "2",
    3
  ],
  "id": 1
}
$ curl -c cookie-jar.txt -b cookie-jar.txt http://rem-rest-api.herokuapp.com/api/foo
{
  "message": "Unexpected token , in JSON at position 0",
  "stack": "SyntaxError: Unexpected token , in JSON at position 0\n   [...]"
}
```
This [line](https://github.com/lhorie/rem/blob/master/CSV.js#L9) seems to skip one more character than needed. I extracted the relevant code into a fiddle for debugging: https://jsfiddle.net/chromy/s3axm4b7/11/

After the fix:
```
$ curl -c cookie-jar.txt -b cookie-jar.txt -X POST \
    --header "Content-Type: application/json" \
    --data '{"items":[1,"2",3]}'  \
    localhost:8000/api/foo
{
  "items": [
    1,
    "2",
    3
  ],
  "id": 1
}
$ curl -c cookie-jar.txt -b cookie-jar.txt localhost:8000/api/foo
{
  "data": [
    {
      "items": [
        1,
        "2",
        3
      ],
      "id": 1
    }
  ],
  "offset": 0,
  "limit": 10,
  "total": 1
}
```

2) `req.headers.origin` is not necessarily set in all situations and now node seems to throw an error if you attempt to set `Access-Control-Allow-Origin` to undefined. I switched all uses of `req.headers.origin` to `req.headers.origin || ''` to avoid this.

Thanks again!